### PR TITLE
Prevent loading .DS_Store files

### DIFF
--- a/cli/tasks/init/yeoman.js
+++ b/cli/tasks/init/yeoman.js
@@ -262,7 +262,11 @@ yeoman.remotes = function _remotes(props, cb) {
 
   // prompt for inclusion on remaining remotes (bootstrap, compass bootstrap)
   var repos = Object.keys(remotes).map(function(remote) {
-    return new remotes[remote]({ props: props, grunt: grunt });
+  	// Node.js loads hidden files (.DS_Store) when doing
+  	// require() against a folder, we don't want those
+  	if (remote[0] !== '.') {
+      return new remotes[remote]({ props: props, grunt: grunt });
+  	}
   }).sort(function(a, b) {
     return a.priority < b.priority ? -1 : 1;
   });


### PR DESCRIPTION
Yeoman throws after every time you visit the /remotes folder on Mac, which is very annoying This is because Node.js apparently also loads hidden files like .DS_Store when doing `require('./folder')`.
