### PR TITLE
Add in optipng and libjpeg as Homebrew packages. Fixes #19

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -5,7 +5,7 @@
 
 
 # packages to automatically be installed
-PACKAGES='git'
+PACKAGES='git optipng libjpeg'
 
 # checking baseline dependencies
 XCODEFILE=$(which xed)
@@ -44,7 +44,7 @@ then
 	echo "RVM is installed..."
 else
 	echo "Installing RVM..."
-	bash < <(curl -L get.rvm.io | bash -s stable )
+	curl -L get.rvm.io | bash -s stable
 fi
 
 
@@ -86,5 +86,3 @@ done
 # some gems are required in the Gemfile.
 echo "Installing bundler-specified gems"
 bundle install
-
-


### PR DESCRIPTION
You'll notice there aren't any changes to the img task, well @mklabs did such a great job with it that I didn't see the need for any big changes. We'll have to revisit it later on when we add Windows support to Yeoman.

This pull adds optipng and libjpeg to the homebrew packages list. Will update with libjpeg-turbo when the open homebrew [pull request](https://github.com/mxcl/homebrew/pull/11894) lands.

There was also a bug with the RVM install line i needed to fix to actually test that it worked.

Also fixes #45
