### PR TITLE
Remove uneeded homebrew function in setup

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -16,16 +16,6 @@ JAVAFILE=$(which java)
 ANTFILE=$(which ant)
 ANDROIDFILE=$(which android)
 
-function check_or_install_brew_pkg() {
-	FILELOCATION=$(which $1)
-	if [ "$FILELOCATION" ]
-	then
-		echo "$1 is installed..."
-	else
-		echo "Installing $1..."
-		brew install $1
-	fi
-}
 
 # Due to bug in xcode install xed may not be in path
 # ref http://stackoverflow.com/questions/7317785/terminal-xed-command-missing-after-new-xcode-install
@@ -33,7 +23,7 @@ if [ "$XCODEFILE" ] || [ -x "/Developer/usr/bin/xed" ]
 then
 	echo "XCode is installed..."
 else
-	echo "XCode is not installed. Please install XCode 4.3+ from http://itunes.apple.com/us/app/xcode/id448457090?mt=12"
+	echo "XCode is not installed. Please install XCode 4.3+ from http://itunes.apple.com/no/app/xcode/id497799835"
 	exit 1
 fi
 
@@ -56,6 +46,8 @@ else
 	ruby -e "$(curl -fsSL https://raw.github.com/gist/323731)"
 fi
 
+brew install ${PACKAGES}
+
 
 if [ "$JAVAFILE" ]
 then
@@ -64,8 +56,6 @@ else
 	echo "Java is not installed. Please install java from http://www.java.com/en/download/index.jsp"
 	exit 1
 fi
-
-
 
 
 BUNDLERFILE=$(gem which bundler)
@@ -78,10 +68,6 @@ else
 	echo "Bundler is installed..."
 fi
 
-for package in $PACKAGES
-do
-	check_or_install_brew_pkg $package
-done
 
 # some gems are required in the Gemfile.
 echo "Installing bundler-specified gems"


### PR DESCRIPTION
Homebrew allows us to specify multiple packages in a row and will give us an error if it already exists, so no need to duplicate that.

Also fixed a broken link.
