### PR TITLE
Add SASS task

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,8 @@
     "faye-websocket": "~0.4.2",
     "prompt": "~0.2.1",
     "underscore": "1.3.3",
-    "colors": "~0.6.0"
+    "colors": "~0.6.0",
+    "grunt-sass": "https://nodeload.github.com/sindresorhus/grunt-sass/tarball/a8e563ac6a"
   },
   "devDependencies": {
     "mocha": "~1.2"


### PR DESCRIPTION
As discussed in #124

Added my grunt-sass task as a dependency for people who would want to use vanilla sass instead of compass. It supports both node-sass and the old, slow, and stable Ruby SASS.

[Docs](https://github.com/sindresorhus/grunt-sass/tree/using-grunt-0-4)

I think the thought here is that we document that it's available, but we don't add it in as default. Much like we'll do with some of the grunt-contrib tasks. ?
