### PR TITLE
Generate man pages via ronnjs, add a doc/ dir and generated man/ folder

### DIFF
--- a/cli/doc/bower.md
+++ b/cli/doc/bower.md
@@ -1,0 +1,27 @@
+yeoman-bower(1) -- Specifics of yeoman's bower handling
+=======================================================
+
+## SYNOPSIS
+
+    yeoman install
+    yeoman uninstall
+    yeoman update
+    yeoman list
+    yeoman search
+    yeoman lookup
+
+## DESCRIPTION
+
+These commands ...
+
+* install: Install a package from the clientside package registry
+* uninstall: Uninstall the package
+* update: Update a package to the latest version
+* list: List the packages currently installed
+* search: Query the registry for matching package names
+* lookup: Look up info on a particular package
+
+## SEE ALSO
+
+* yeoman-faq(1)
+* yeoman-folders(1)

--- a/cli/doc/build.md
+++ b/cli/doc/build.md
@@ -1,0 +1,14 @@
+yeoman-build(1) -- Build an optimized version of your app, ready to deploy
+==========================================================================
+
+## SYNOPSIS
+
+    yeoman build
+
+## DESCRIPTION
+
+This command ...
+
+## SEE ALSO
+
+* yeoman-folders(1)

--- a/cli/doc/faq.md
+++ b/cli/doc/faq.md
@@ -1,0 +1,12 @@
+yeoman-faq(1) -- Frequently Asked Questions
+===========================================
+
+## But Whyyyyyyy?
+
+That's not really a question.
+
+## SEE ALSO
+
+* yeoman(1)
+* yeoman-folders(1)
+* yeoman-gruntfile(1)

--- a/cli/doc/folders.md
+++ b/cli/doc/folders.md
@@ -1,0 +1,14 @@
+yeoman-folders(1) -- Folder Structures Used by yeoman
+=====================================================
+
+## DESCRIPTION
+
+When you generate a new application or trigger a new build, yeoman puts various
+things on your computer.
+
+This document will tell you what it puts where.
+
+## SEE ALSO
+
+* yeoman-faq(1)
+* yeoman-gruntfile(1)

--- a/cli/doc/gruntfile.md
+++ b/cli/doc/gruntfile.md
@@ -1,0 +1,19 @@
+yeoman-gruntfile(1) -- Specifics of yeoman's Gruntfile handling
+===============================================================
+
+## DESCRIPTION
+
+This document is all you need to know about what's required in your
+`Gruntfile.js` file.
+
+A lot of the behavior described in this document is affected by the config
+settings described in Grunt's Gettint Started guide:
+https://github.com/cowboy/grunt/blob/master/docs/getting_started.md
+
+## DEFAULT VALUES
+
+...
+
+## SEE ALSO
+
+* yeoman-faq(1)

--- a/cli/doc/init.md
+++ b/cli/doc/init.md
@@ -1,0 +1,14 @@
+yeoman-init(1) -- Initialize and scaffold a new project
+=======================================================
+
+## SYNOPSIS
+
+    yeoman init
+
+## DESCRIPTION
+
+This command ...
+
+## SEE ALSO
+
+* yeoman-folders(1)

--- a/cli/doc/insight.md
+++ b/cli/doc/insight.md
@@ -1,0 +1,11 @@
+yeoman-insight(1) -- Specifics of yeoman insight
+================================================
+
+## DESCRIPTION
+
+This document is all you need to know about what's done with insight, how it
+works, what it does, and how you can configure its behaviour.
+
+## SEE ALSO
+
+* yeoman-folders(1)

--- a/cli/doc/server.md
+++ b/cli/doc/server.md
@@ -1,0 +1,14 @@
+yeoman-server(1) -- Launch a preview server
+===========================================
+
+## SYNOPSIS
+
+    yeoman server
+
+## DESCRIPTION
+
+This command ...
+
+## SEE ALSO
+
+* yeoman-folders(1)

--- a/cli/doc/test.md
+++ b/cli/doc/test.md
@@ -1,0 +1,14 @@
+yeoman-test(1) -- Runs a test suite in a headless PhantomJS
+===========================================================
+
+## SYNOPSIS
+
+    yeoman test
+
+## DESCRIPTION
+
+This command ...
+
+## SEE ALSO
+
+* yeoman-folders(1)

--- a/cli/doc/yeoman.md
+++ b/cli/doc/yeoman.md
@@ -1,0 +1,118 @@
+yeoman(1) -- Yeoman CLI tool
+============================
+
+## What am I?
+
+Yeoman is a robust and opinionated client-side stack, comprised of tools and
+frameworks that can help developers quickly build beautiful web applications.
+We take care of providing everything needed to get started without any of the
+normal headaches associated with a manual setup.
+
+Yeoman is fast, performant and is optimized to work best in modern browsers.
+
+For more information about the project, see
+[http://yeoman.io](http://yeoman.io).
+
+## Installing
+
+* Clone this repo and `cd` into it
+* Run the following command at the terminal:
+
+```shell
+./setup/install.sh
+```
+
+* Navigate to a new directory and run `yeoman init` to make sure everything is
+  working as expected.
+
+
+### Trouble-shooting
+
+If for any reason you experience exceptions after the yeoman installation
+process above, you may find the following steps resolve these issues:
+
+```
+$ cd yeoman/cli
+$ sudo npm install -g
+# when complete then run..
+$ sudo npm link
+```
+
+## Running
+
+Here's a small shell script that you can save as `server.sh` which opens and
+servers the current directory on the port specified:
+
+```shell
+port=$1
+if [ $#  -ne  1 ]
+then
+  port=8000
+fi
+
+if [ $(uname -s) == "Darwin" ]
+then
+  open=open
+else
+  open=xdg-open
+fi
+
+$open http://localhost:$port && python -m SimpleHTTPServer $port;
+```
+
+For example, run this guy as:
+
+```shell
+./server.sh 8000
+```
+
+
+## Documentation
+
+The current documentation for Yeoman can be found
+[here](http://yeoman.github.com/docs). If you are a new contributor and require
+access to this repository, feel free to ask.
+
+
+## Browser Support
+
+Yeoman supports:
+
+* Modern browsers (latest versions of Chrome, Safari, Firefox, Opera and IE10)
+* Chrome on Android
+* Mobile Safari
+
+
+## Contribute
+
+### Repos
+
+* [Yeoman (CLI, Insights)](http://github.com/yeoman/yeoman)
+* [Yeoman I/O Holding Page](http://github.com/yeoman/yeoman.io)
+* [Yeoman I/O Site](http://github.com/yeoman/yeoman.io)(site branch)
+* [Yeoman Docs](http://github.com/yeoman/docs)
+
+### Style Guide
+
+This project follows the [jQuery Style
+Guide](http://docs.jquery.com/JQuery_Core_Style_Guidelines) with an exception
+of two space indentation and multiple var statements. Please ensure any pull
+requests follow this closely. If you notice existing code which doesn't follow
+these practices, feel free to shout and we will address this.
+
+## About
+
+Yeoman is an open-source project by Google which builds on top of a number of
+open-source solutions. These include Grunt, Twitter Bootstrap and Compass.
+Version 1 of the project features the combined efforts of:
+
+* Paul Irish
+* Addy Osmani
+* Mickael Daniel
+* Sindre Sorhus
+* [Eric Bidelman](http://ericbidelman.com)
+
+and other developers.
+
+We will be aiming to officially release the project in late July, 2012.
+

--- a/cli/man/bower.1
+++ b/cli/man/bower.1
@@ -1,0 +1,53 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-BOWER" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-bower\fR \-\- Specifics of yeoman\'s bower handling
+.
+.SH "SYNOPSIS"
+.
+.nf
+yeoman install
+yeoman uninstall
+yeoman update
+yeoman list
+yeoman search
+yeoman lookup
+.
+.fi
+.
+.SH "DESCRIPTION"
+These commands \.\.\.
+.
+.IP "\(bu" 4
+install: Install a package from the clientside package registry
+.
+.IP "\(bu" 4
+uninstall: Uninstall the package
+.
+.IP "\(bu" 4
+update: Update a package to the latest version
+.
+.IP "\(bu" 4
+list: List the packages currently installed
+.
+.IP "\(bu" 4
+search: Query the registry for matching package names
+.
+.IP "\(bu" 4
+lookup: Look up info on a particular package
+.
+.IP "" 0
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-faq(1)
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/build.1
+++ b/cli/man/build.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-BUILD" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-build\fR \-\- Build an optimized version of your app, ready to deploy
+.
+.SH "SYNOPSIS"
+.
+.nf
+yeoman build
+.
+.fi
+.
+.SH "DESCRIPTION"
+This command \.\.\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/faq.1
+++ b/cli/man/faq.1
@@ -1,0 +1,24 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-FAQ" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-faq\fR \-\- Frequently Asked Questions
+.
+.SH "But Whyyyyyyy?"
+That\'s not really a question\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman(1)
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "\(bu" 4
+yeoman\-gruntfile(1)
+.
+.IP "" 0
+

--- a/cli/man/folders.1
+++ b/cli/man/folders.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-FOLDERS" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-folders\fR \-\- Folder Structures Used by yeoman
+.
+.SH "DESCRIPTION"
+When you generate a new application or trigger a new build, yeoman puts various
+things on your computer\.
+.
+.P
+This document will tell you what it puts where\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-faq(1)
+.
+.IP "\(bu" 4
+yeoman\-gruntfile(1)
+.
+.IP "" 0
+

--- a/cli/man/gruntfile.1
+++ b/cli/man/gruntfile.1
@@ -1,0 +1,26 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-GRUNTFILE" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-gruntfile\fR \-\- Specifics of yeoman\'s Gruntfile handling
+.
+.SH "DESCRIPTION"
+This document is all you need to know about what\'s required in your \fBGruntfile\.js\fR file\.
+.
+.P
+A lot of the behavior described in this document is affected by the config
+settings described in Grunt\'s Gettint Started guide:
+https://github\.com/cowboy/grunt/blob/master/docs/getting_started\.md
+.
+.SH "DEFAULT VALUES"
+\|\.\.\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-faq(1)
+.
+.IP "" 0
+

--- a/cli/man/init.1
+++ b/cli/man/init.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-INIT" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-init\fR \-\- Initialize and scaffold a new project
+.
+.SH "SYNOPSIS"
+.
+.nf
+yeoman init
+.
+.fi
+.
+.SH "DESCRIPTION"
+This command \.\.\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/insight.1
+++ b/cli/man/insight.1
@@ -1,0 +1,19 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-INSIGHT" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-insight\fR \-\- Specifics of yeoman insight
+.
+.SH "DESCRIPTION"
+This document is all you need to know about what\'s done with insight, how it
+works, what it does, and how you can configure its behaviour\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/serve.1
+++ b/cli/man/serve.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-SERVER" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-server\fR \-\- Launch a preview server
+.
+.SH "SYNOPSIS"
+.
+.nf
+yeoman server
+.
+.fi
+.
+.SH "DESCRIPTION"
+This command \.\.\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/server.1
+++ b/cli/man/server.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-SERVER" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-server\fR \-\- Launch a preview server
+.
+.SH "SYNOPSIS"
+.
+.nf
+yeoman server
+.
+.fi
+.
+.SH "DESCRIPTION"
+This command \.\.\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/test.1
+++ b/cli/man/test.1
@@ -1,0 +1,25 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN\-TEST" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman-test\fR \-\- Runs a test suite in a headless PhantomJS
+.
+.SH "SYNOPSIS"
+.
+.nf
+yeoman test
+.
+.fi
+.
+.SH "DESCRIPTION"
+This command \.\.\.
+.
+.SH "SEE ALSO"
+.
+.IP "\(bu" 4
+yeoman\-folders(1)
+.
+.IP "" 0
+

--- a/cli/man/yeoman.1
+++ b/cli/man/yeoman.1
@@ -1,0 +1,151 @@
+.\" Generated with Ronnjs 0.3.8
+.\" http://github.com/kapouer/ronnjs/
+.
+.TH "YEOMAN" "1" "July 2012" "" ""
+.
+.SH "NAME"
+\fByeoman\fR \-\- Yeoman CLI tool
+.
+.SH "What am I?"
+Yeoman is a robust and opinionated client\-side stack, comprised of tools and
+frameworks that can help developers quickly build beautiful web applications\.
+We take care of providing everything needed to get started without any of the
+normal headaches associated with a manual setup\.
+.
+.P
+Yeoman is fast, performant and is optimized to work best in modern browsers\.
+.
+.P
+For more information about the project, see \fIhttp://yeoman\.io\fR\|\.
+.
+.SH "Installing"
+.
+.IP "\(bu" 4
+Clone this repo and \fBcd\fR into it
+.
+.IP "\(bu" 4
+Run the following command at the terminal:
+.
+.IP "" 0
+.
+.P
+\fBshell
+\|\./setup/install\.sh\fR
+.
+.IP "\(bu" 4
+Navigate to a new directory and run \fByeoman init\fR to make sure everything is
+working as expected\.
+.
+.IP "" 0
+.
+.SS "Trouble\-shooting"
+If for any reason you experience exceptions after the yeoman installation
+process above, you may find the following steps resolve these issues:
+.
+.P
+\fB
+$ cd yeoman/cli
+$ sudo npm install \-g
+# when complete then run\.\.
+$ sudo npm link\fR
+.
+.SH "Running"
+Here\'s a small shell script that you can save as \fBserver\.sh\fR which opens and
+servers the current directory on the port specified:
+.
+.P
+\fB\fR`shell
+port=$1
+if [ $#  \-ne  1 ]
+then
+  port=8000
+fi
+.
+.P
+if [ $(uname \-s) == "Darwin" ]
+then
+  open=open
+else
+  open=xdg\-open
+fi
+.
+.P
+$open http://localhost:$port && python \-m SimpleHTTPServer $port; \fB\fR`
+.
+.P
+For example, run this guy as:
+.
+.P
+\fBshell
+\|\./server\.sh 8000\fR
+.
+.SH "Documentation"
+The current documentation for Yeoman can be found here \fIhttp://yeoman\.github\.com/docs\fR\|\. If you are a new contributor and require
+access to this repository, feel free to ask\.
+.
+.SH "Browser Support"
+Yeoman supports:
+.
+.IP "\(bu" 4
+Modern browsers (latest versions of Chrome, Safari, Firefox, Opera and IE10)
+.
+.IP "\(bu" 4
+Chrome on Android
+.
+.IP "\(bu" 4
+Mobile Safari
+.
+.IP "" 0
+.
+.SH "Contribute"
+.
+.SS "Repos"
+.
+.IP "\(bu" 4
+Yeoman (CLI, Insights) \fIhttp://github\.com/yeoman/yeoman\fR
+.
+.IP "\(bu" 4
+Yeoman I/O Holding Page \fIhttp://github\.com/yeoman/yeoman\.io\fR
+.
+.IP "\(bu" 4
+Yeoman I/O Site \fIhttp://github\.com/yeoman/yeoman\.io\fR(site branch)
+.
+.IP "\(bu" 4
+Yeoman Docs \fIhttp://github\.com/yeoman/docs\fR
+.
+.IP "" 0
+.
+.SS "Style Guide"
+This project follows the jQuery Style
+Guide \fIhttp://docs\.jquery\.com/JQuery_Core_Style_Guidelines\fR with an exception
+of two space indentation and multiple var statements\. Please ensure any pull
+requests follow this closely\. If you notice existing code which doesn\'t follow
+these practices, feel free to shout and we will address this\.
+.
+.SH "About"
+Yeoman is an open\-source project by Google which builds on top of a number of
+open\-source solutions\. These include Grunt, Twitter Bootstrap and Compass\.
+Version 1 of the project features the combined efforts of:
+.
+.IP "\(bu" 4
+Paul Irish
+.
+.IP "\(bu" 4
+Addy Osmani
+.
+.IP "\(bu" 4
+Mickael Daniel
+.
+.IP "\(bu" 4
+Sindre Sorhus
+.
+.IP "\(bu" 4
+Eric Bidelman \fIhttp://ericbidelman\.com\fR
+.
+.IP "" 0
+.
+.P
+and other developers\.
+.
+.P
+We will be aiming to officially release the project in late July, 2012\.

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,10 +4,13 @@
   "description": "The Yeoman CLI presents a command line interface for creating, building, maintaining, and shipping a project.",
   "version": "0.0.1",
   "homepage": "http://yeoman.io",
+  "main": "./yeoman",
   "bin": {
     "yeoman": "./bin/yeoman"
   },
-  "main": "./yeoman",
+  "directories": {
+    "man": "./man"
+  },
   "dependencies": {
     "grunt": "https://nodeload.github.com/cowboy/grunt/tarball/0ba6d4b529",
     "open": "0.0.2",
@@ -33,9 +36,11 @@
     "colors": "~0.6.0"
   },
   "devDependencies": {
-    "mocha": "~1.2"
+    "mocha": "~1.2",
+    "ronn": "~0.3.8"
   },
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha --reporter nyan test/tasks/test-*.js --silent"
+    "test": "node node_modules/mocha/bin/mocha --reporter nyan test/tasks/test-*.js --silent",
+    "manpages": "./scripts/docs-build"
   }
 }

--- a/cli/scripts/docs-build
+++ b/cli/scripts/docs-build
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+DOCS_FILES=$(find doc/*.md)
+MAN_FOLDER=man/
+RONN=./node_modules/.bin/ronn
+
+mkdir -p $MAN_FOLDER
+
+function ronnify {
+  $RONN --roff $1 > $2
+}
+
+for file in $DOCS_FILES; do
+  docpath=${file/doc/man}
+  ronnify $file ${docpath/.md/.1}
+done
+


### PR DESCRIPTION
Related to #128.
- Added a doc dir with few documentation pages, could act as a placeholder to write further documentation.
- Ronnjs is added as a devDependency, this is not required to use yeoman, users won't have to install this additionnal dep.
- Added a simple `script/docs-build` script, used to generate the `man/` folder from `doc/*.md`
- Register the `man/` dir as an npm directory. It will tell npm to link them at the proper place for `man` to find them.

I've included the man/ folder full of man pages already, the `docs-build` script added can be used to re-generate them when we need to.

``` shell
$ cd cli/
$ npm run-script manpages
$ # or ./script/docs-build
```

To see the man pages, we should relink the project with `npm link`. We can then see the yeoman documentation with:
- `man yeoman`
- `man yeoman-bower`
- `man yeoman-build`
- `man yeoman-faq`
- `man yeoman-folders`
- `man yeoman-gruntfile`
- `man yeoman-init`
- `man yeoman-insight`
- `man yeoman-serve`
- `man yeoman-server`
- `man yeoman-test`
- `man yeoman-yeoman`
