### PR TITLE
Creating appcache-manifest fails when space in path

### DIFF
--- a/cli/tasks/manifest.js
+++ b/cli/tasks/manifest.js
@@ -20,7 +20,7 @@ var fs = require('fs'),
         // Tell grunt this task is asynchronous.
         var done = this.async(),
             exec = require('child_process').exec,
-            command = 'phantomjs ' +  confessPath  + ' ' + localServer +' ' + confessTask + ' >' + manifestTarget + ' ' + confessConfig;
+            command = 'phantomjs "' +  confessPath  + ' ' + localServer +' ' + confessTask + '" > ' + manifestTarget + ' "' + confessConfig + '"';
 
         command += this.args.join(' ');
 


### PR DESCRIPTION
When running the build task one of the options that includes building the manifest (e.g. `yeoman build:basics`) the build fails if you got a space in the absolute path of your project.

This may happen if one of your main drives is called "Macintosh HD" or "Macintosh SSD" and you use this in somehow (e.g. with symlinks).

You can prevent this by using quotes around the paths.
