### PR TITLE
generators - minox fix in simpleapp gen with async handler

### DIFF
--- a/cli/lib/generators/base.js
+++ b/cli/lib/generators/base.js
@@ -5,8 +5,8 @@ var fs = require('fs'),
   events = require('events'),
   wiring = require('./wiring'),
   actions = require('./actions'),
-  _ = require('underscore'),
-  grunt = require('grunt');
+  grunt = require('grunt'),
+  _ = grunt.util._;
 
 module.exports = Base;
 

--- a/cli/lib/generators/yeoman/simpleapp/index.js
+++ b/cli/lib/generators/yeoman/simpleapp/index.js
@@ -210,7 +210,6 @@ AppGenerator.prototype.fetchPackage = function fetchPackage() {
 
 AppGenerator.prototype.writeMain = function writeMain(){
   this.log.writeln('Writing compiled Bootstrap');
-  var cb = this.async();
   this.template('main.css', path.join('app/css/main.css'));
 };
 


### PR DESCRIPTION
Hi,

A little patch on the app generator:
- minox fix in simpleapp generator to remove an unused async handler. It prevents the generator from completing and triggering the according hooks / subgenerators.
- base, also fix an error with _.humanize. Ensures we use underscore from grunt.util.

I think this is kinda related to #164, and may help in fixing it.
