### PR TITLE
Installer: Remove `npm link` since it isn't needed and breaks the install

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -190,7 +190,6 @@ echo "We're going to move fast, but once we're done, "
 echo "you'll have the power of a thousand developers at your blinking cursor."
 echo "Okay here we go..."
 sudo npm install . -g
-sudo npm link
 
 echo ""
 echo "Yah Hoo! Yeoman global is in place, now for some housekeeping.."


### PR DESCRIPTION
Related to #184

@paulirish Can you update the tarball in Dropbox? It's outdated. Just paste the link here.

@commadelimited Can you try it out an confirm when we've also updated the tarball?
