### PR TITLE
Prevent yeoman from failing build if min directives are missing

### DIFF
--- a/cli/lib/generators/yeoman/app/templates/Gruntfile.js
+++ b/cli/lib/generators/yeoman/app/templates/Gruntfile.js
@@ -166,6 +166,16 @@ module.exports = function( grunt ) {
       baseUrl: './scripts',
       wrap: true
     },
+
+    // While Yeoman handles concat/min when using
+    // usemin blocks, you can still use them manually
+    concat: {
+      dist: ''
+    },
+
+    min: {
+      dist: ''
+    }
   });
 
   // Alias the `test` task to run the `mocha` task instead


### PR DESCRIPTION
Fixes #247

@mklabs As you suggested, it works, but I'm not sure it's the best solution. I don't like the idea of having to clutter up the users Gruntfile with internal stuff.

Some other solutions:
- Just fill the `grunt.config('concat')` (and min) on build. But it would still show up in `Configuration is now:`
- Alias the default concat/min task and only execute if there are targets
