### PR TITLE
Only include compiled bootstrap, when Compass Bootstrap is not selected

### DIFF
--- a/cli/lib/generators/yeoman/app/index.js
+++ b/cli/lib/generators/yeoman/app/index.js
@@ -158,6 +158,9 @@ AppGenerator.prototype.compassBootstrapFiles = function compassBootstrapFiles() 
 
       cb();
     });
+  } else {
+    this.log.writeln('Writing compiled Bootstrap');
+    this.copy( 'bootstrap.css', 'app/styles/bootstrap.css' );
   }
 };
 
@@ -325,11 +328,6 @@ AppGenerator.prototype.requirehm = function requirehm(){
   } else {
     cb();
   }
-};
-
-AppGenerator.prototype.writeVanillaBootstrap = function writeVanillaBootstrap() {
-  this.log.writeln('Writing compiled Bootstrap');
-  this.copy( 'bootstrap.css', 'app/styles/bootstrap.css' );
 };
 
 AppGenerator.prototype.app = function app() {


### PR DESCRIPTION
@addyosmani I don't think it makes sense to include the compiled bootstrap.css when the user has chosen Compass Bootstrap. Merge if you agree.
