### PR TITLE
(Attempted) CLI tools checks. (And sudo keep alive)

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -36,13 +36,15 @@ if [ "$MAC" -eq 1 ]; then
   if haveProg clang; then
     echo "CLI tools check 1/2 passed."
   else
-    echo "CLI tools not found. You can download them here: https://developer.apple.com/downloads"
+    echo "Looks like you need the XCode CLI Tools for homebrew, chap. Learn about
+where to install them at the homebrew docs: https://github.com/mxcl/homebrew/wiki/Installation"
     exit 1
   fi
   if haveProg lldb; then
     echo "CLI tools check 2/2 passed."
   else
-    echo "CLI tools not found. You can download them here: https://developer.apple.com/downloads"
+    echo "Looks like you need the XCode CLI Tools for homebrew, chap. Learn about
+where to install them at the homebrew docs: https://github.com/mxcl/homebrew/wiki/Installation"
     exit 1
   fi
 fi


### PR DESCRIPTION
This should in theory work for checking for the Xcode CLI tools on OS X. #298

Also added sudo keep alive, thanks Mathias 
