### PR TITLE
Fixes running tests ignore's process.env.yeoman_test

### DIFF
--- a/cli/bin/yeoman
+++ b/cli/bin/yeoman
@@ -50,6 +50,12 @@ function init() {
     cli.tasks = cmds.join(':');
   }
 
+  // specific flag to ensure we bypass insight prompt when running the test task
+  if(/^test/.test(route)) {
+    var env = process.env;
+    env.yeoman_test = true;
+  }
+
   // add the plugin version on `--version`
   if(opts.version) {
     return console.log('%s  v%s', pkg.name, pkg.version);


### PR DESCRIPTION
set's the `yeoman_test` flag when we try to run the `test` task
