### PR TITLE
change 'Phantom.js' to 'PhantomJS' in docs

### DIFF
--- a/cli/bin/help.txt
+++ b/cli/bin/help.txt
@@ -5,7 +5,7 @@
       <%= 'init'.yellow %>  <%= 'Initialize and scaffold a new project using generator templates'.grey %>
      <%= 'build'.yellow %>  <%= 'Build an optimized version of your app, ready to deploy'.grey %>
     <%= 'server'.yellow %>  <%= 'Launch a preview server which will begin watching for changes'.grey %>
-      <%= 'test'.yellow %>  <%= 'Run a Mocha test harness in a headless Phantom.js'.grey %>
+      <%= 'test'.yellow %>  <%= 'Run a Mocha test harness in a headless PhantomJS'.grey %>
 
    <%= 'install'.yellow %>  <%= 'Install a package from the clientside package registry'.grey %>
  <%= 'uninstall'.yellow %>  <%= 'Uninstall the package'.grey %>

--- a/docs/cli/commands/help.md
+++ b/docs/cli/commands/help.md
@@ -9,7 +9,7 @@ Lists out the commands and tasks supported by yeoman and should print out the fo
 yeoman init      # Initialize and scaffold a new project using generator templates
 yeoman build     # Build an optimized version of your app, ready to deploy
 yeoman server    # Launch a preview server which will begin watching for changes
-yeoman test      # Run a Mocha test harness in a headless Phantom.js
+yeoman test      # Run a Mocha test harness in a headless PhantomJS
 
 yeoman install   # Install a package from the clientside package registry
 yeoman uninstall # Uninstall the package

--- a/docs/cli/commands/test.md
+++ b/docs/cli/commands/test.md
@@ -4,7 +4,7 @@
 
 Usage: `yeoman test`
 
-Runs a Mocha test harness in a headless instance of Phantom.js.
+Runs a Mocha test harness in a headless instance of PhantomJS.
 
 When you generate a new project using `yeoman init`, we also scaffold out a basic set of
 Mocha unit tests that you can continue using to test your application.

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Yeoman supports a powerful set of high-level commands. These include:
 yeoman init      # Initialize and scaffold a new project using generator templates
 yeoman build     # Build an optimized version of your app, ready to deploy
 yeoman server    # Launch a preview server which will begin watching for changes
-yeoman test      # Run a Mocha test harness in a headless Phantom.js
+yeoman test      # Run a Mocha test harness in a headless PhantomJS
 
 yeoman install   # Install a package from the client-side package registry
 yeoman uninstall # Uninstall the package


### PR DESCRIPTION
The upstream project seems to use "PhantomJS".
