### PR TITLE
Fix html entities in docs/cli/package_manager.md

### DIFF
--- a/docs/cli/package_manager.md
+++ b/docs/cli/package_manager.md
@@ -36,7 +36,7 @@ This approach has a number of benefits.
 The easiest approach is to use a Bower package statically is to then just reference the package manually from a script tag:
 
 {% highlight sh %}
-&lt;script src="components/modernizr/modernizr.js"&gt;&lt;/script&gt;
+<script src="components/modernizr/modernizr.js"></script>
 {% endhighlight %}
 
 Similar to NPM, our Bower integration also allows users to easily search for and update packages easily. e.g


### PR DESCRIPTION
This fixes an error with `<script>` elements in [package_manager.html](http://yeoman.io/packagemanager.html).

The line currently shows up like this:

`&lt;script src="components/modernizr/modernizr.js"&gt;&lt;/script&gt`
