### PR TITLE
Possible fix for Ubuntu 12.04

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -119,7 +119,7 @@ fi
 
 # packages to automatically be installed
 PACKAGESMAC='git optipng jpeg-turbo phantomjs'
-PACKAGESLINUX='optipng libjpeg-turbo8 phantomjs'
+PACKAGESLINUX='optipng libjpeg-turbo-progs phantomjs'
 DEBGIT='git-core'
 OTHERGIT='git'
 


### PR DESCRIPTION
This is targeting Ubuntu 12.04 Precise: The Ubuntu package
`libjpeg-turbo8` only includes the libs. This results in an error when 
running `yeoman build`:

```
Running jpegtran...ERROR
In order for this task to work properly, jpegtran must be installed
and in the system PATH (if you can run "jpegtran" at the command line, this
task should work)

Skiping jpegtran task
```

Changing this to `libjpeg-turbo-progs` will install related executables
(including `jpegtran`) in addition to the core `libjpeg-turbo8` package.
