### PR TITLE
Correct preview server port number in docs

### DIFF
--- a/docs/cli/commands/server.md
+++ b/docs/cli/commands/server.md
@@ -4,7 +4,7 @@
 
 Usage: `yeoman server`
 
-Launches a preview server on port 3051 that allows you to access a running version of your application locally.
+Launches a preview server on port 3501 that allows you to access a running version of your application locally.
 
 It also automatically fires up the `yeoman watch` process, so changes to any of the applications
 files cause the browser to refresh via [LiveReload](http://livereload.com). Should you not have


### PR DESCRIPTION
Docs say `3051`, but in reality the port default is `3501`.
