### PR TITLE
Support for an expanded compass --require arg

### DIFF
--- a/cli/tasks/compass.js
+++ b/cli/tasks/compass.js
@@ -18,6 +18,12 @@ module.exports = function( grunt ) {
       if ( _.isString( val ) ) {
         args.push( '--' + el, val );
       }
+
+      if( _.isArray( val ) ) {
+        val.forEach(function( subval ) {
+          args.push( '--' + el, subval );
+        });
+      }
     });
 
     return args;


### PR DESCRIPTION
As it stands, the Gruntfile compass configuration will only let me require 1 compass plugin via the `--require` arg.

This change to the `optsToArgs` function would allow arrays in the config and properly expand them for the spawn util.

So for example:

``` javascript
    ...
    compass: {
      dist: {
        require: ['modular-scale', 'susy'],
    ...
```

would get properly expanded to:
`--require modular-scale --require susy`
