### PR TITLE
Stops yeoman from looking for win32 binaries in ../vendor/

### DIFF
--- a/cli/tasks/img.js
+++ b/cli/tasks/img.js
@@ -145,17 +145,11 @@ module.exports = function(grunt) {
     }
   });
 
-  // **which** helper, wrapper to isaacs/which package plus some fallback logic
-  // specifically for the win32 binaries in vendor/ (optipng.exe, jpegtran.exe)
+  // **which** helper, wrapper to isaacs/which package
   grunt.registerHelper('which', function(cmd, cb) {
-    if ( !win32 || !/optipng|jpegtran/.test( cmd ) ) {
+    if ( win32 || !/optipng|jpegtran/.test( cmd ) ) {
       return which( cmd, cb );
     }
-
-    var cmdpath = cmd === 'optipng' ? '../vendor/optipng-0.7.1-win32/optipng.exe' :
-      '../vendor/jpegtran-8d/jpegtran.exe';
-
-    cb(null, path.join(__dirname, cmdpath));
   });
 };
 


### PR DESCRIPTION
This fixes an [issue](https://github.com/yeoman/yeoman/issues/216#issuecomment-8621841) where Yeoman searches for optipng.exe and jpegtran.exe in ../vendor/ on Windows. Since those files aren't there anymore this will render an error when you are running build.

This commit will treat Windows like any other system and search for the libraries in PATH instead.
