### PR TITLE
Made server init tasks configurable

### DIFF
--- a/cli/tasks/server.js
+++ b/cli/tasks/server.js
@@ -271,7 +271,7 @@ module.exports = function(grunt) {
         }
     });
 
-    grunt.task.run( tasks[target] );
+    grunt.task.run(grunt.config('server.initTasks') || tasks[target]);
   });
 
   grunt.registerHelper('server', function(opts, cb) {


### PR DESCRIPTION
Allows you to change the tasks run before starting the server from 

```
'clean coffee compass open-browser'
```

If an initTasks property is added to the server config in the gruntfile it will use it.  If not, it will default to the existing tasks.
