### PR TITLE
Changelog for v0.9.1 is ready

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,17 @@
+### 0.9.1 (15 September, 2012)
+
+* Removal of stdout checks, test against fs (Pull [#473](https://github.com/yeoman/yeoman/pull/473)).
+
+* Fix for  initializer example (Pull [#447](https://github.com/yeoman/yeoman/pull/477 )).
+
+* Support for an expanded compass --require arg (Pull [#483](https://github.com/yeoman/yeoman/pull/483)).   
+
+* Yeoman setup gets a colored art (Pull [#493](https://github.com/yeoman/yeoman/pull/493))!
+
+* Added ability to configure app index file for rjs task (Pull [#505](https://github.com/yeoman/yeoman/pull/505)).
+
+* yeoman server:test and access to the app js files (Issue [#443](https://github.com/yeoman/yeoman/issues/443)).
+
+* yeoman install backbone deletes existing files in app/scripts/vendor issue was fixed (Issue [#460](https://github.com/yeoman/yeoman/issues/460)).
+
+* Replaced coffescript task with grunt-coffee (Pull[#522](https://github.com/yeoman/yeoman/pull/522))


### PR DESCRIPTION
### 0.9.1 (15 September, 2012)
- Removal of stdout checks, test against fs (Pull [#473](https://github.com/yeoman/yeoman/pull/473)).
- Fix for  initializer example (Pull [#447](https://github.com/yeoman/yeoman/pull/477)).
- Support for an expanded compass --require arg (Pull [#483](https://github.com/yeoman/yeoman/pull/483)).   
- Yeoman setup gets a colored art (Pull [#493](https://github.com/yeoman/yeoman/pull/493))!
- Added ability to configure app index file for rjs task (Pull [#505](https://github.com/yeoman/yeoman/pull/505)).
- yeoman server:test and access to the app js files (Issue [#443](https://github.com/yeoman/yeoman/issues/443)).
- yeoman install backbone deletes existing files in app/scripts/vendor issue was fixed (Issue [#460](https://github.com/yeoman/yeoman/issues/460)).
- Replaced coffescript task with grunt-coffee (Pull[#522](https://github.com/yeoman/yeoman/pull/522))
