### PR TITLE
Simple fix for contributing link in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ You can follow its guidance or simply walk through the [installation procedure](
 
 ## Issue submission
 
-Make sure you've read the [issue submission guidelines](yeoman/blob/master/contributing.md#issue-submission) before you open a [new issue](https://github.com/yeoman/yeoman/issues/new).
+Make sure you've read the [issue submission guidelines](https://github.com/yeoman/yeoman/blob/master/contributing.md#issue-submission) before you open a [new issue](https://github.com/yeoman/yeoman/issues/new).
 
 
 ## Documentation


### PR DESCRIPTION
Link was using a bad relative path.  I'm assuming the docs were moved or something.
