### PR TITLE
Include grunt-contrib-ember to enable ember support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -57,7 +57,8 @@
     "colors": "~0.6.0",
     "grunt-mocha": "~0.1.3",
     "es6-collections": ">=0.2.0",
-    "grunt-contrib-coffee": "~0.3.1"
+    "grunt-contrib-coffee": "~0.3.1",
+    "grunt-contrib-ember": ">=0.1.0"
   },
   "devDependencies": {
     "mocha": "~1.4.0",

--- a/cli/tasks/yeoman.js
+++ b/cli/tasks/yeoman.js
@@ -22,6 +22,7 @@ module.exports = function(grunt) {
   grunt.loadTasks(join(__dirname, '../node_modules/grunt-jasmine-task/tasks'));
   grunt.loadTasks(join(__dirname, '../node_modules/grunt-mocha/tasks'));
   grunt.loadTasks(join(__dirname, '../node_modules/grunt-contrib-coffee/tasks'));
+  grunt.loadTasks(join(__dirname, '../node_modules/grunt-contrib-ember/tasks'));
 
   // build targets: these are equivalent to grunt alias except that we defined
   // a single task and use arguments to trigger the appropriate target


### PR DESCRIPTION
I've just created a new grunt plugin, [grunt-contrib-ember](https://github.com/dgeb/grunt-contrib-ember), which uses headless ember to compile handlebars templates and insert them into the `Ember.TEMPLATES` namespace. This pull request includes this plugin so that it will be available for ember projects.

I wrote `grunt-contrib-ember` because the other handlebars compilers don't work well for ember. Ember templates need to be compiled with headless ember, which rules out [grunt-contrib-handlebars](https://github.com/gruntjs/grunt-contrib-handlebars). A closer fit is [grunt-ember-handlebars](https://github.com/yaymukund/grunt-ember-handlebars), but this doesn't construct ember template names that match directories (e.g. the template in `contacts/show.hbs` should be named `contacts/show`, not just `show`). Also, I wanted to build a plugin compatible with `grunt-contrib`.

These problems are discussed in issue #455.

As it stands, the ember generators are broken for ember 1.0.pre. If this gets accepted, I'll try to patch those up too so that yeoman will work out of the box with ember. I've written a [working, very simple yeoman / grunt-contrib-ember example](https://github.com/dgeb/yeoman-ember-basic-example) for reference.
