### PR TITLE
Installing Yeoman behind a corporate proxy server

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,8 +33,8 @@
     "manpages": "./scripts/docs-build"
   },
   "dependencies": {
-    "grunt": "https://nodeload.github.com/cowboy/grunt/tarball/0ba6d4b529",
-    "yeoman-generators": "https://nodeload.github.com/yeoman/generators/tarball/282b0b4c51",
+    "grunt": "http://nodeload.github.com/cowboy/grunt/tarball/0ba6d4b529",
+    "yeoman-generators": "http://nodeload.github.com/yeoman/generators/tarball/282b0b4c51",
     "bower": "~0.1.0",
     "open": "0.0.2",
     "rimraf": "~2.0.1",


### PR DESCRIPTION
Installing Yeoman through npm behind a corporate proxy server fails in our case, since Yeoman relies on two tarballs which are loaded through HTTPS.

I have configured the proxy and https-proxy settings in npm, yet still npm is not able to download through HTTPS.

Installing Yeoman fails with the following error:

```
npm ERR! fetch failed https://nodeload.github.com/cowboy/grunt/tarball/0ba6d4b529
npm ERR! fetch failed https://nodeload.github.com/yeoman/generators/tarball/282b0b4c51
```

Changing the two tarball URLs in `package.json` from HTTPS to HTTP fixes this issue for me.
