### PR TITLE
Precede "test" static files in server task

### DIFF
--- a/cli/tasks/server.js
+++ b/cli/tasks/server.js
@@ -1,4 +1,3 @@
-
 var fs = require('fs'),
   path = require('path'),
   util = require('util'),
@@ -284,6 +283,9 @@ module.exports = function(grunt) {
       middleware.push( grunt.helper('reload:inject', opts) );
     }
 
+    // also serve static files from the test directory, and before the temp
+    // one (compiled assets takes precedence over same pathname within temp/)
+    middleware.push(connect.static(path.join(opts.base, '../test')));
     // also serve static files from the temp directory, and before the app
     // one (compiled assets takes precedence over same pathname within app/)
     middleware.push(connect.static(path.join(opts.base, '../temp')));


### PR DESCRIPTION
Hi,

I'm using yeoman in the angular project I'm working on right now and I need to load static files from "test" directory to run my e2e tests on the browser.
Runner.html is the file a need to load to run my e2e tests.
This file is under "test" directory (which is at the same level of my "app" directory) and has to be here.
I need to have loaded "test" static files once my app is running for two reasons:
- This way I'm able to navigate to runner.html even if runner.html is not in the "app" directory.
- In my tests I need to navigate to paths relatives to "app" and this way all paths are correct.

I thought this might be usefull for those who need e2e coverage of their web applications under yeoman so I decide to make a pull request of this change.
I've got another revision of this commit where I created a new target ("e2e") to the task, This way we only precede "test" static files over "temp" ones and "app" ones if we run yeoman server:e2e. But in this revision I also changed the url we open in the browser to runner.html,
I don't know which revision would be better so I decided to request this one as it's simpler (although affects to all task's targets.
