### PR TITLE
Add exec path for OS X

### DIFF
--- a/sublime/yeoman.sublime-build
+++ b/sublime/yeoman.sublime-build
@@ -1,5 +1,5 @@
 {
 	"cmd": ["yeoman", "build", "--no-color"],
 	"selector": ["source.js", "source.less", "source.json"],
-	"path": "/usr/local/bin"
+	"path": "/usr/local/bin:/usr/bin"
 }


### PR DESCRIPTION
Add extra path for common OS X paths. In order to fix the the error when you try to build.

`env: python: No such file or directory`
