### PR TITLE
Usemin Task - Determine linefeed from the content not the platform

### DIFF
--- a/cli/tasks/usemin.js
+++ b/cli/tasks/usemin.js
@@ -148,8 +148,6 @@ function getBlocks(body) {
 
 module.exports = function(grunt) {
 
-  var linefeed = grunt.util.linefeed;
-
   grunt.registerMultiTask('usemin', 'Replaces references to non-minified scripts / stylesheets', function() {
 
     var name = this.target,
@@ -291,6 +289,9 @@ module.exports = function(grunt) {
     // directive --> for html, /** directive **/ for css
     var blocks = getBlocks(content);
 
+    // Determine the linefeed from the content
+    var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n';
+
     // handle blocks
     Object.keys(blocks).forEach(function(key) {
       var block = blocks[key].join(linefeed),
@@ -311,11 +312,13 @@ module.exports = function(grunt) {
   });
 
   grunt.registerHelper('usemin:css', function(content, block, target) {
+    var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n';
     var indent = (block.split(linefeed)[0].match(/^\s*/) || [])[0];
     return content.replace(block, indent + '<link rel="stylesheet" href="' + target + '"\/>');
   });
 
   grunt.registerHelper('usemin:js', function(content, block, target) {
+    var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n';
     var indent = (block.split(linefeed)[0].match(/^\s*/) || [])[0];
     return content.replace(block, indent + '<script src="' + target + '"></script>');
   });


### PR DESCRIPTION
This fixes #485 and #649.

usemin.js was using the platform linefeed (\r\n in windows) to join the block lines, then trying to replace this generated block with the new script tag.
`return content.replace(block, indent + '<script src="' + target + '"></script>');`

Since it couldn't find the `block joined with '\r\n'` in `file with '\n' for EOL` it would fail silently, without replacing the text.

Instead we should detect the EOL-type from the content.
`var linefeed = /\r\n/g.test(content) ? '\r\n' : '\n';`
