### PR TITLE
broken angular directive generator

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "grunt": "http://nodeload.github.com/gruntjs/grunt/tarball/0ba6d4b529",
-    "yeoman-generators": "http://nodeload.github.com/yeoman/generators/tarball/3d709c61cd",
+    "yeoman-generators": "http://nodeload.github.com/yeoman/generators/tarball/ccaf4fca6e",
     "bower": "~0.3.0",
     "open": "0.0.2",
     "rimraf": "~2.0.1",


### PR DESCRIPTION
The angular:directive generator included with yeoman 0.9.4 can't find the template to use for angular directives.

This generators were recently fixed so the link to tarball needs to be updated.
