### PR TITLE
Properly handle rjs options.dir if used

### DIFF
--- a/cli/tasks/rjs.js
+++ b/cli/tasks/rjs.js
@@ -49,7 +49,8 @@ module.exports = function(grunt) {
     rjs.optimize(options, function(out) {
       grunt.log.writeln(out);
       originals.forEach(function(m) {
-        var filepath = path.join(options.dir, options.baseUrl, m.name + '.js');
+	var basePath = options.dir || options.baseUrl;
+        var filepath = path.join(basePath, m.name + '.js');
         grunt.log
           .writeln('rjs optimized module: ' + m.name)
           .writeln('>> ' + filepath);


### PR DESCRIPTION
In rjs task if options.dir is set it is an absolute path, so using path.join on it and options.baseUrl (also an absolute path) creates a path to non-existant files. This is helpful if building named modules with rjs rather than a single file from usemin.
