### PR TITLE
Add server.watch -option for disabling watch and livereload

### DIFF
--- a/cli/tasks/server.js
+++ b/cli/tasks/server.js
@@ -171,7 +171,11 @@ module.exports = function(grunt) {
 
   // The server task always run with the watch task, this is done by
   // aliasing the server task to the relevant set of task to run.
-  grunt.registerTask('server', 'yeoman-server watch');
+  if ( grunt.config('server.watch') !== false ) {
+    grunt.registerTask('server', 'yeoman-server watch');
+  } else {
+    grunt.registerTask('server', 'yeoman-server');
+  }
 
   // Reload handlers
   // ---------------
@@ -263,6 +267,14 @@ module.exports = function(grunt) {
       hostname: grunt.config('server.hostname') || 'localhost'
     };
 
+    if ( grunt.config('server.watch') === false ) {
+      opts.inject = false;
+      tasks[target] = tasks[target].replace(/watch$/, '');
+
+      // disable async
+      cb = undefined;
+    }
+
     grunt.helper('server', opts, cb);
 
     grunt.registerTask('open-browser', function() {
@@ -270,7 +282,9 @@ module.exports = function(grunt) {
           open( 'http://' + opts.hostname + ':' + opts.port );
         }
     });
-    grunt.task.run(grunt.config('server.' + target) || tasks[target]);
+    if ( tasks[target] !== "" ) {
+      grunt.task.run(grunt.config('server.' + target) || tasks[target]);
+    }
   });
 
   grunt.registerHelper('server', function(opts, cb) {
@@ -339,14 +353,15 @@ module.exports = function(grunt) {
           .writeln('I\'ll also watch your files for changes, recompile if neccessary and live reload the page.')
           .writeln('Hit Ctrl+C to quit.');
 
-        // create the reactor object
-        grunt.helper('reload:reactor', {
-          server: this,
-          apiVersion: '1.7',
-          host: opts.hostname,
-          port: port
-        });
-
+        if ( opts.inject ) {
+          // create the reactor object
+          grunt.helper('reload:reactor', {
+            server: this,
+            apiVersion: '1.7',
+            host: opts.hostname,
+            port: port
+          });
+        }
         cb(null, port);
       });
   });

--- a/docs/cli/commands/server.md
+++ b/docs/cli/commands/server.md
@@ -27,6 +27,16 @@ The built-in server also supports serving different profiles of your application
 * `yeoman server:test` serves up the test suite and your `app`. It also ensure any change to your code or tests will cause the browser to refresh.
 * `yeoman server:reload` forces the port to be LiveReload standard port: 35729 and prevents the automatic default browser opening. Handy for those wishing to use livereload extensions with other systems / HTTP servers than the one provided by Yeoman out of the box.
 
+### disabling watch on server tasks
+
+To disable watching of files and livereloading, add following section to your Gruntfile.
+
+{% highlight javascript %}
+    server: {
+        watch: false
+    }
+{% endhighlight %}
+
 ### further notes
 
 At present, when initially running `yeoman server` or `yeoman server:app`, some users may find that their browser is opened before intermediate files such as Compass and CoffeeScript have completed compiling. Whilst we intend on fixing this issue very soon, in the mean time we recommend refreshing the browser shortly after you first fire up the server (e.g 10 seconds after). You can then easily make any changes you wish to your application and the browser will be automatically reloaded via LiveReload.


### PR DESCRIPTION
Useful for testing-servers.
In my environments watch just eats way too much resources without
even doing anything useful. I'm pretty sure I'm not only one here.
