### PR TITLE
Fix #622

### DIFF
--- a/cli/tasks/bower.js
+++ b/cli/tasks/bower.js
@@ -32,135 +32,13 @@ module.exports = function(grunt) {
       return grunt.fatal('A valid bower command should be specified.');
     }
 
-    // figure out the alternate install location, if any
-    var directory = grunt.config('bower.dir');
-
     // run
     var cb = this.async();
     command.line(process.argv)
       .on('error', grunt.fatal.bind(grunt.fail))
-      .on('data', grunt.log.writeln.bind(grunt.log))
-      .on('end', function(){
-
-        grunt.helper('bower:sync', directory, cb);
-        /*
-        if(args[0] === 'install' && directory) {
-          grunt.helper('bower:sync', directory, cb);
-        } else if(args[0] === 'uninstall' || args[0] === 'update' && directory) {
-          grunt.helper('bower:sync', directory, cb);
-        } else {
-          cb();
-        }*/
-      });
+      .on('data', grunt.log.writeln.bind(grunt.log));
   });
 
-
-  // This helper returns a function meant to be used as a direct callback, most
-  // likely on the end event of a bower command.
-  //
-  // Bower's list is used to get the paths of each dependency in
-  // components/, these deps are simply copied over the directory
-  // specified.
-  //
-  // - dir: directory path to mirror bower's components.
-  // - cb: callback to call on completion.
-  //
-  // Examples:
-  //
-  //      stuff.on('end', grunt.helper('bower:copy', this.async()));
-  //
-  grunt.registerHelper('bower:copy', function(dir, cb) {
-    if(typeof cb !== 'function') {
-      return grunt.fatal('bower:copy helper requires a callback.');
-    }
-
-    if(!dir) {
-      return grunt.fatal('bower:copy helper requires a directory path.');
-    }
-
-    // Resolve application index
-    var scripts = '';
-    var basePath = 'app';
-    var appIndexPath  = path.resolve(path.join(basePath + '/index.html'));
-    var indexBuffer = fs.readFileSync(appIndexPath, 'utf8');
-
-    // parse data-main for require config path
-    var datamain = /data-main=['"]([^'"]+)['"]/;
-
-    // Syncronize the components directory with the vendor directory
-    // if we're not having an rjs setup, go through synchronize step directly
-    if(!datamain.test(indexBuffer)){
-      return grunt.helper('bower:sync', dir, cb);
-    }
-
-    // store the relative filepath of the rjs entry point
-    var filepath = indexBuffer.match(datamain)[1];
-
-    // otherwise, request bower for deps listing and update the relevant config
-    // while going through to synchronize step when done
-    bower.commands.list({ paths: true })
-      .on('error', grunt.fatal.bind(grunt.fail))
-      .on('data', function(deps) {
-        // should probably emit on `end` in bower's internal
-        if(typeof deps === 'string') { return; }
-
-        // Handler for RequireJS app config.
-        // Wires up the relevant RequireJS paths config when
-        // running `yeoman install spine backbone` etc.
-
-        var requireConfigPath = basePath + '/' + filepath;
-
-        // check path contains .js, append if not
-        if ( requireConfigPath.indexOf('.js') ) {
-          requireConfigPath += '.js';
-        }
-
-        // check config file exists
-        var configExists = grunt.file.exists(requireConfigPath);
-        if(configExists) {
-          grunt.helper('bower:log', 'Updating RequireJS config: ' + requireConfigPath);
-          // if so..
-          // iterate over Bower deps, generating the path string fo config
-          Object.keys(deps).forEach(function(dep){
-            // Quote key if it contains non a-z chars
-            var key = /[^\w]/.test( dep ) ? '\'' + dep + '\'' : dep;
-            scripts+= "    " + key + ": '../../" + deps[dep].replace('.js','') + "',\n";
-          });
-
-          // read in the existing data-main config
-          var cf = fs.readFileSync(requireConfigPath, 'utf8');
-          // replace the existing paths with your new paths
-          var html = cf.replace(' paths: {', 'paths: {\n' + scripts);
-
-          // Write the paths to config
-          fs.writeFileSync(requireConfigPath, html, 'utf8');
-        }
-
-        // end the process
-        grunt.helper('bower:sync', dir, cb);
-      });
-  });
-
-
-
-  // Helper to syncronize the Bower components directory with app/scripts/vendor
-  grunt.registerHelper('bower:sync', function(dir, cb) {
-    // Clean the vendor directory then sync with the components directory
-
-    if(typeof cb !== 'function') {
-      return grunt.fatal('bower:sync helper requires a callback.');
-    }
-
-    if(!dir) {
-      return grunt.fatal('bower:sync helper requires a directory path.');
-    }
-
-    shelljs.rm('-rf', dir);
-    shelljs.mkdir('-p', dir);
-    shelljs.cp('-R', 'components/*', dir);
-
-    cb();
-  });
 
   // Little grunt helper to access the bower template facility.
   //

--- a/cli/test/test-bower.js
+++ b/cli/test/test-bower.js
@@ -50,15 +50,15 @@ describe('Bower install packages', function() {
       bower.list({ map: true })
         .on('error', done)
         .on('data', function(results) {
-          
+
           ctx.results = results;
           var pkg = results[name];
-          
+
           var source = ctx[name] = pkg.source.main;
           var vendor = source.replace(/^components/, 'app/components');
           fs.stat(vendor, done);
-          
-        
+
+
         });
 
         */


### PR DESCRIPTION
It removes the process of copying `components/*` (populated by bower) into `app/components`. It should be merged at the same time as yeoman/generators#126
