### PR TITLE
Setup script on FreeBSD

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -19,7 +19,7 @@ os=$(uname -s)
 
 if [[ "$os" == "Darwin" ]]; then
   mac=1
-elif [[ "$os" == "Linux" ]]; then
+elif [[ "$os" == "Linux" || "$os" == "FreeBSD" ]]; then
   linux=1
 else
   echo "Windows is not officially supported, currently."


### PR DESCRIPTION
FreeBSD is not supported by your dependencies & system audit script right now, although it can be treated as Linux OS there.
With this fix script operates just fine on FreeBSD 9
