### PR TITLE
Add FreeBSD to supported platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ Yeoman uses [Bower](http://twitter.github.com/bower/) as its package manager. Th
 
 ## Platform Support
 
-Yeoman 1.0 will support OS X and Linux. We will be aiming to bring in support for Windows in a [future](https://github.com/yeoman/yeoman/issues/216) version of the project.
+Yeoman 1.0 will support OS X, Linux and FreeBSD. We will be aiming to bring in support for Windows in a [future](https://github.com/yeoman/yeoman/issues/216) version of the project.
 
 
 ## Contribute


### PR DESCRIPTION
Hi,
I can confirm that I use Yeoman on latest version of FreeBSD and it works just like it works on my Linux machine.
I wrote a small guide on how to get Yeoman up and running from scratch on FreeBSD: http://sergeylukin.com/2012/yeoman-on-freebsd-9/
