### PR TITLE
Added Support for renaming data-* attributes as per img src's

### DIFF
--- a/cli/tasks/usemin.js
+++ b/cli/tasks/usemin.js
@@ -340,6 +340,9 @@ module.exports = function(grunt) {
 
     grunt.log.verbose.writeln('Update the HTML with the new img filenames');
     content = grunt.helper('replace', content, /<img[^\>]+src=['"]([^"']+)["']/gm);
+	
+    grunt.log.verbose.writeln('Update the HTML with the data tags');
+    content = grunt.helper('replace', content, /data-[A-Za-z0-9]*=['"]([^"']+)["']/gm);
 
     grunt.log.verbose.writeln('Update the HTML with background imgs, case there is some inline style');
     content = grunt.helper('replace', content, /url\(\s*['"]([^"']+)["']\s*\)/gm);

--- a/cli/test/test-usemin.js
+++ b/cli/test/test-usemin.js
@@ -88,6 +88,14 @@ describe('usemin', function() {
       var changed = grunt.helper('usemin:post:html', content);
       assert.ok( changed == awaited );
     });
+	
+    it('should also replace data-* links', function() {
+      grunt.file.write('images/23012.foo.png', "foo");
+      var content = '<a href="http://foo/bar"></a><a href="ftp://bar"></a><a href="images/foo.png"></a><a href="/images/foo.png"></a><a href="#local"></a><img data-thumb="/images/foo.png" /><img data-text="foo-bar" />';
+      var awaited = '<a href="http://foo/bar"></a><a href="ftp://bar"></a><a href="images/23012.foo.png"></a><a href="/images/23012.foo.png"></a><a href="#local"></a><img data-thumb="/images/23012.foo.png" /><img data-text="foo-bar" />';
+      var changed = grunt.helper('usemin:post:html', content);
+      assert.ok( changed == awaited );
+    });
 
     it('should handle properly the case of the root path (/)', function() {
       var content = '<a href="/">'


### PR DESCRIPTION
Hello there,
When using libraries such as Nivo Slider etc, these make use of data-thumbnail etc attributes which are images that are renamed.

I have therefore extended this to support all data-\* attributes

Any issues/queries let me know.
