### PR TITLE
trigger offline appcache update only when resources change

### DIFF
--- a/cli/lib/support/confess.js
+++ b/cli/lib/support/confess.js
@@ -167,14 +167,12 @@ var confess = {
 
       console.log('CACHE MANIFEST');
       console.log('');
-      console.log('# Time: ' + new Date());
       if (config.verbose) {
-        console.log('# This manifest was created by confess.js, http://github.com/jamesgpearce/confess');
+        console.log('# This manifest was created by a slightly modified version of confess.js');
+        console.log('#   http://github.com/jamesgpearce/confess');
         console.log('#');
-        console.log('# Retrieved URL: ' + this.getFinalUrl(page));
-        console.log('# User-agent: ' + page.settings.userAgent);
-        console.log('#');
-        this.emitConfig(config, '# ');
+        console.log('# Offline cache busting is handled by the file hashes below.');
+        console.log('# In the future, we hope browsers will update only resource file names that change, instead of every resource.');
       }
       console.log('');
       console.log('CACHE:');


### PR DESCRIPTION
Including a time stamp and other miscellaneous information in an appcache comment will mean browsers will update the appcache everytime the new manifest.appcache is uploaded, even if the sub-resources don't change.

How are updates triggered then? The file name hashes yeoman helps produce in html in `dist/`

This also paves the way for browser vendors to change html5 offline update behavior to only update the changed sub-resources, not every single resource.

This means yeoman now offers the easiest A-grade html5 offline support.

:100:
