### PR TITLE
Add support for compass single-dash short options in grunt

### DIFF
--- a/cli/tasks/compass.js
+++ b/cli/tasks/compass.js
@@ -11,17 +11,19 @@ module.exports = function( grunt ) {
 
       el = el.replace( /_/g, '-' );
 
+      var prefix = el.length == 1 ? '-' : '--';
+
       if ( val === true ) {
-        args.push( '--' + el );
+        args.push( prefix + el );
       }
 
       if ( _.isString( val ) ) {
-        args.push( '--' + el, val );
+        args.push( prefix + el, val );
       }
 
       if( _.isArray( val ) ) {
         val.forEach(function( subval ) {
-          args.push( '--' + el, subval );
+          args.push( prefix + el, subval );
         });
       }
     });


### PR DESCRIPTION
The current compass task assumes long options, but some compass options are only available in short form, like import_path. With this change, you can do this:

``` javascript
    // compile .scss/.sass to .css using Compass
    compass: {
      dist: {
        // http://compass-style.org/help/tutorials/configuration-reference/#configuration-properties
        options: {
          css_dir: 'temp/styles',
          sass_dir: 'app/styles',
          images_dir: 'app/images',
          javascripts_dir: 'temp/scripts',
          I: [
            'app/scripts/components'
          ],
          force: true
        }
      }
    },
```

And then importing from bower-installed projects becomes a bit simpler:

``` sass
@import "sass-twitter-bootstrap/lib/bootstrap"
@import "sass-twitter-bootstrap/lib/responsive"
```
