### PR TITLE
http://yeoman.io/installation.html has an encoding issue with the script tag.  This pre-encodes it.

### DIFF
--- a/docs/cli/commands/install.md
+++ b/docs/cli/commands/install.md
@@ -20,7 +20,7 @@ As mentioned, the files for these dependencies will be added to `app/components`
 Example:
 
 {% highlight html %}
-<script src="components/spine/lib/spine.js"></script>
+&lt;script src="components/spine/lib/spine.js"&gt;&lt;/script&gt;
 {% endhighlight %}
 
 If installing a dependency which has its own dependencies described, these dependencies will also be pulled in.


### PR DESCRIPTION
The documentation has an encoding issue on the live page (it displays '&gt;')
