### PR TITLE
fixes grunt file path with spaces issue

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -6,8 +6,8 @@ module.exports = function( grunt ) {
 
   grunt.loadNpmTasks('grunt-shell');
 
-  var angularcrudPath = path.resolve('./generators/angularcrud');
-  var expressPath = path.resolve('./generators/express');
+  var angularcrudPath = path.resolve('./generators/angularcrud').replace(" ", "\\ ");
+  var expressPath = path.resolve('./generators/express').replace(" ", "\\ ");
 
   grunt.initConfig({
     shell: {


### PR DESCRIPTION
Fixes https://github.com/yeoman/express-stack/issues/12

Issue happens when grunt creates symbolic links path for generators and the it contains spaces
