### PR TITLE
Add --force for brew link jpeg-turbo

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -373,7 +373,7 @@ msgs_jpegtran() {
                 mac )
                     if [ $brew -eq 1 ]; then
                         desc_print "To install $outputName use:" \
-                                   "brew install jpeg-turbo && brew link jpeg-turbo"
+                                   "brew install jpeg-turbo && brew link jpeg-turbo --force"
                     else
                         desc_print "Download $outputName from:" \
                                    "http://libjpeg-turbo.virtualgl.org"


### PR DESCRIPTION
A change for mxcl/homebrew#13349 made brew linking jpeg-turbo
uneffective without the --force handle.
