### PR TITLE
Make the open-browser task optional

### DIFF
--- a/yeoman-custom/cli/tasks/server.js
+++ b/yeoman-custom/cli/tasks/server.js
@@ -1,4 +1,3 @@
-
 var fs = require('fs'),
     path = require('path'),
     util = require('util'),
@@ -259,7 +258,7 @@ module.exports = function(grunt) {
 
     opts = {
       // prevent browser opening on `reload` target
-      open: target !== 'reload',
+      open: grunt.config('server.open') && target !== 'reload',
       // and force 35729 port no matter what when on `reload` target
       port: target === 'reload' ? 35729 : port,
       base: base,


### PR DESCRIPTION
Hi,

   As the server is not automatically reload while changing the Node.js code, I thought is could be nicer to let developers disabling the open-browser feature.

   It's not ideal but that allows people to use nodemon (or equivalent tools) while waiting a more advance feature directly included in the express-stack.

Hope that can help

Thank you

Aurélien
