### PR TITLE
Added sponsors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,100 @@ Yeoman is beautifully crafted by these people and a bunch of awesome [contributo
 :---:|:---:|
 [Kevin Mårtensson](https://github.com/kevva) | [Arthur Verschaeve](https://github.com/arthurvr)
 
+# Sponsors
+Love Yeoman work and community? Help us keep it alive by donating funds to cover project expenses! <br />
+[[Become a sponsor](https://opencollective.com/yeoman#support)]
+
+  <a href="https://opencollective.com/yeoman/backers/0/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/0/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/1/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/1/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/2/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/2/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/3/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/3/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/4/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/4/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/5/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/5/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/6/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/6/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/7/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/7/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/8/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/8/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/9/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/9/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/10/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/10/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/11/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/11/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/12/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/12/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/13/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/13/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/14/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/14/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/15/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/15/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/16/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/16/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/17/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/17/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/18/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/18/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/19/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/19/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/20/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/20/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/21/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/21/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/22/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/22/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/23/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/23/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/24/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/24/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/25/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/25/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/26/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/26/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/27/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/27/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/28/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/28/avatar">
+  </a>
+  <a href="https://opencollective.com/yeoman/backers/29/website" target="_blank">
+    <img src="https://opencollective.com/yeoman/backers/29/avatar">
+  </a>
 
 ## License
 


### PR DESCRIPTION
It will automatically show the avatar/logo of the top backers of Yeoman on OpenCollective (https://opencollective.com/yeoman) (and link to their website or Twitter)