### PR TITLE
Add PowerShell issue details command

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -14,8 +14,10 @@ In order for us to help you please check that you've completed the following ste
 
 Unix: `yo --version && echo $PATH $NODE_PATH && node -e 'console.log(process.platform, process.versions)'`
 
-Windows: `yo --version && echo %PATH% %NODE_PATH% && node -e "console.log(process.platform, process.versions)"`  
-  
+Windows (cmd.exe): `yo --version && echo %PATH% %NODE_PATH% && node -e "console.log(process.platform, process.versions)"`
+
+Windows (PowerShell): `yo --version; echo %PATH% %NODE_PATH%; node -e "console.log(process.platform, process.versions)"`
+
 [Submit your issue](https://github.com/yeoman/yeoman/issues/new)
 
 


### PR DESCRIPTION
Ran into an issue when I copied the existing Windows command into PowerShell because the `&&` isn't supported there. I added a version that should provide similar output for someone running the command in [Windows] PowerShell or PowerShell Core.

Error with existing command:

```
At line:1 char:14
+ yo --version && echo %PATH% %NODE_PATH% && node -e "console.log(proce ...
+              ~~
The token '&&' is not a valid statement separator in this version.
...
```